### PR TITLE
[#62] Added support for v-model.

### DIFF
--- a/src/components/DruxtMenu.vue
+++ b/src/components/DruxtMenu.vue
@@ -20,9 +20,7 @@ export default {
 
   extends: DruxtModule,
 
-  /**
-   * Vue.js Properties.
-   */
+  /** */
   props: {
     /**
      * The depth of the menu items to render.
@@ -184,11 +182,13 @@ export default {
       parent: this.parentId,
     }
 
-    await this.getMenu({
-      name: this.name,
-      settings,
-    })
-    this.items = this.getMenuItems()
+    if (!this.value) {
+      await this.getMenu({
+        name: this.name,
+        settings,
+      })
+      this.model = this.getMenuItems()
+    }
 
     // Build wrapper component propsData.
     component = { ...component, ...this.getModulePropsData(wrapperData.props) }
@@ -202,25 +202,24 @@ export default {
     return [...parts, getCounter(parts.join(':'))].join(':')
   },
 
-  /**
-   * Vue.js Data object.
-   *
-   * @property {objects[]} items - The processed Menu items.
-   */
-  data: () => ({
-    items: [],
-  }),
-
-  /**
-   * Vue.js Computed properties.
-   */
+  /** */
   computed: {
     /**
-     * The active route trail.
+     * The processed Menu items.
+     * 
+     * @type {objects[]}
+     * @deprecated
      */
-    trail() {
+    items: ({ model }) => model,
+
+    /**
+     * The active route trail.
+     * 
+     * @type {string[]}
+     */
+    trail: ({ $route }) => {
       const paths = []
-      const parts = this.$route.path.substring(1).split('/')
+      const parts = $route.path.substring(1).split('/')
 
       for (const key in parts) {
         const path = [key > 0 ? paths[key - 1] : '', parts[key]].join('/')
@@ -239,9 +238,7 @@ export default {
     })
   },
 
-  /**
-   * Nuxt.js watch property.
-   */
+  /** */
   watch: {
     /**
      * Updates menu when available Entities change.
@@ -296,9 +293,7 @@ export default {
     })
   },
 
-  /**
-   * Druxt module configuration.
-   */
+  /** DruxtModule settings. */
   druxt: {
     /**
      * Provides the available component naming options for the Druxt Wrapper.
@@ -314,7 +309,7 @@ export default {
      * @param {object} context - The module component ViewModel.
      * @returns {PropsData}
      */
-    propsData: ({ items, parentId }) => ({ items, parentId }),
+    propsData: ({ model, parentId }) => ({ items: model, parentId, value: model }),
 
     /**
      * Provides the scoped slots object for the Module render function.
@@ -394,10 +389,17 @@ export default {
  *
  * @typedef {object} PropsData
  * @param {object[]} items - The Menu items structured data.
+ * @param {object[]} value - The Menu items structured data.
  *
  * @example @lang js
  * {
  *   items: [
+ *     {
+ *       children: [],
+ *       entity: {},
+ *     },
+ *   ],
+ *   value: [
  *     {
  *       children: [],
  *       entity: {},

--- a/src/components/__tests__/DruxtMenu.test.js
+++ b/src/components/__tests__/DruxtMenu.test.js
@@ -97,6 +97,10 @@ describe('DruxtMenu', () => {
     await wrapper.vm.$options.fetch.call(wrapper.vm)
 
     wrapper.vm.getScopedSlots().default()
-    expect(scopedSlots.default).toHaveBeenCalledWith({ items: wrapper.vm.items, parentId: wrapper.vm.parentId })
+    expect(scopedSlots.default).toHaveBeenCalledWith({
+      items: wrapper.vm.model,
+      parentId: wrapper.vm.parentId,
+      value: wrapper.vm.model,
+    })
   })
 })


### PR DESCRIPTION
+ Added support for v-model

```
<DruxtMenu :value="[{ entity: {}, children: [] }]" />
```

```
<template>
  <DruxtMenu v-model="menuItems" />
</template>

<script>
export default {
  data: () => ({
    menuItems: [{
      entity: {},
      children: [],
    }]
  })
}
</script>
```

/closes #62 